### PR TITLE
Accept u-umlaut in street names.

### DIFF
--- a/src/jhs_106/reg.clj
+++ b/src/jhs_106/reg.clj
@@ -8,6 +8,8 @@
 (def SMALL_O_WITH_DIARESIS "\u00F6") ; ö
 (def CAPITAL_E_WITH_ACUTE "\u00C9") ; É
 (def SMALL_E_WITH_ACUTE "\u00E9") ; é
+(def CAPITAL_U_WITH_UMLAUT "\u00DC") ; Ü
+(def SMALL_U_WITH_UMLAUT "\u00FC") ; ü
 (def ACUTE_ACCENT "\u00B4") ; ´
 (def APOSTROPHE "\u0027") ; '
 (def SMALL_LETTERS "a-z")
@@ -17,10 +19,12 @@
                         SMALL_A_WITH_DIARESIS
                         SMALL_A_WITH_RING_ABOVE
                         SMALL_E_WITH_ACUTE
+                        SMALL_U_WITH_UMLAUT
                         CAPITAL_O_WITH_DIARESIS
                         CAPITAL_A_WITH_DIARESIS
                         CAPITAL_A_WITH_RING_ABOVE
-                        CAPITAL_E_WITH_ACUTE))
+                        CAPITAL_E_WITH_ACUTE
+                        CAPITAL_U_WITH_UMLAUT))
 
 (def OTHER (str APOSTROPHE
                 "-/\\.:"

--- a/test/jhs_106/reg_test.clj
+++ b/test/jhs_106/reg_test.clj
@@ -19,7 +19,9 @@
     (is (= "Minna \u00C4kkijyrk\u00E4n penger" (re-matches streetName "Minna \u00C4kkijyrk\u00E4n penger")))
     (is (= "Minna \u00C4kkijyrk\u00E4n pgr." (re-matches streetName "Minna \u00C4kkijyrk\u00E4n pgr.")))
     (is (= "\u00C5lans V\u00E4nstra v\u00E5ning" (re-matches streetName "\u00C5lans V\u00E4nstra v\u00E5ning")))
-    (is (= "\u00C5lans V. v\u00E5n." (re-matches streetName "\u00C5lans V. v\u00E5n.")))))
+    (is (= "\u00C5lans V. v\u00E5n." (re-matches streetName "\u00C5lans V. v\u00E5n.")))
+    (is (= "W\u00FCrthinkatu" (re-matches streetName "W\u00FCrthinkatu")))
+    (is (= "W\u00DCRTHINKATU" (re-matches streetName "W\u00DCRTHINKATU")))))
 
 (deftest should-match-abbreviated-street-name
   (testing "Abbreviated street name matching"


### PR DESCRIPTION
For example "Würthinkatu" is an existing street name.
